### PR TITLE
fix: update the vm box version. The current version is not found

### DIFF
--- a/Exercise_Starter_Files/Vagrantfile
+++ b/Exercise_Starter_Files/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
   config.vm.box = "opensuse/Leap-15.2.x86_64"
-  config.vm.box_version = "15.2.31.199"
+  config.vm.box_version = "15.2.31.354"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
The current vm box version is not found in the vagrant cloud. I changed it for the smooth provisioning of the box.