### PR TITLE
bugfix: Update k3s to stable version v1.19.5+k3s1

### DIFF
--- a/Exercise_Starter_Files/scripts/k3s.sh
+++ b/Exercise_Starter_Files/scripts/k3s.sh
@@ -2,7 +2,7 @@
 echo "**** Begin installing k3s"
 
 #Install
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.19.2+k3s1 K3S_KUBECONFIG_MODE="644" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.19.5+k3s1 K3S_KUBECONFIG_MODE="644" sh -
 echo "**** End installing k3s"
 
 #kubectl proxy --address='0.0.0.0' /dev/null &

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/k3s.sh
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/k3s.sh
@@ -2,7 +2,7 @@
 echo "**** Begin installing k3s"
 
 #Install
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.19.2+k3s1 K3S_KUBECONFIG_MODE="644" sh -
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.19.5+k3s1 K3S_KUBECONFIG_MODE="644" sh -
 echo "**** End installing k3s"
 
 #kubectl proxy --address='0.0.0.0' /dev/null &


### PR DESCRIPTION
https://github.com/udacity/CNAND_nd064_C4_Observability_Starter_Files/issues/16

Theres a IP Table bug in OpenSUSE that can be resolved by pinning k3s version.

https://www.reddit.com/r/openSUSE/comments/96k5jb/broken_iptables_after_systemkernel_upgrade_on/

https://github.com/k3s-io/k3s/releases/tag/v1.19.5+k3s1

https://knowledge.udacity.com/questions/500205

@TheJaySmith 