### PR TITLE
Fix dependencies conflicts

### DIFF
--- a/course-files/tracing-extra/app/Dockerfile
+++ b/course-files/tracing-extra/app/Dockerfile
@@ -9,7 +9,10 @@ COPY . ./
 
 # Install production dependencies.
 RUN pip install -r requirements.txt
+# Install dependecies without installing package depencies to avoid conflicts
+RUN pip install --no-deps redis-opentracing
 
+ENV PORT=7111
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers

--- a/course-files/tracing-extra/app/requirements.txt
+++ b/course-files/tracing-extra/app/requirements.txt
@@ -1,8 +1,9 @@
 Flask==1.1.2
 gunicorn==20.0.4
 opentracing==2.4.0
-jaeger-client==4.3.0
+jaeger-client==4.6.1
 redis==3.5.3
 opentracing==2.4.0
 Flask-OpenTracing==1.1.0
 prometheus-client==0.12.0
+requests==2.26.0


### PR DESCRIPTION
This PR does the following:
- Adds missing port on Dockerfile
- Adds a missing requirement
- Installs `redis-opentracing` dependencies without installing package dependencies to avoid conflicts