### PR TITLE
Update Vagrantfile.sample

### DIFF
--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/Vagrantfile.sample
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/Vagrantfile.sample
@@ -5,6 +5,7 @@
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
+Vagrant.require_version ">= 2.2.10"
 Vagrant.configure("2") do |config|
   # The most common configuration options are documented and commented below.
   # For a complete reference, please see the online documentation at
@@ -14,7 +15,7 @@ Vagrant.configure("2") do |config|
   # boxes at https://vagrantcloud.com/search.
   # Use any version between 15.2.31.300 and 15.2.31.570
   config.vm.box = "opensuse/Leap-15.2.x86_64"
-  config.vm.box_version = "15.2.31.354"
+  config.vm.box_version = "15.2.31.584"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
- Current VM version times out as per https://knowledge.udacity.com/questions/770170
- User should have Vagrant version >= 2.2.10, before continuing to avoid any issues