### PR TITLE
fix: updated image registry address

### DIFF
--- a/Exercise_Starter_Files/sampleapp/k8s/dummy-app.yaml
+++ b/Exercise_Starter_Files/sampleapp/k8s/dummy-app.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: second-sample-app
-          image: ghcr.io/thejaysmith/my-sample-app:v2
+          image: ghcr.io/jasonsmithio/my-sample-app:v2
           imagePullPolicy: Always
           ports:
             - name: backend

--- a/Exercise_Starter_Files/sampleapp/k8s/jaeger-app-1.yaml
+++ b/Exercise_Starter_Files/sampleapp/k8s/jaeger-app-1.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: my-sample-app
-          image: ghcr.io/thejaysmith/my-sample-app:v1
+          image: ghcr.io/jasonsmithio/my-sample-app:v1
           imagePullPolicy: Always
           ports:
             - name: frontend

--- a/Exercise_Starter_Files/sampleapp/k8s/jaeger-app-2.yaml
+++ b/Exercise_Starter_Files/sampleapp/k8s/jaeger-app-2.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: second-sample-app
-          image: ghcr.io/thejaysmith/my-sample-app:v2
+          image: ghcr.io/jasonsmithio/my-sample-app:v2
           imagePullPolicy: Always
           ports:
             - name: backend-port

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/backend.yaml
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/backend.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: ghcr.io/thejaysmith/backend:v1
+        image: ghcr.io/jasonsmithio/backend:v1
         ports:
         - containerPort: 8081
 ---

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/frontend.yaml
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/frontend.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: ghcr.io/thejaysmith/myfrontend:v1
+        image: ghcr.io/jasonsmithio/myfrontend:v1
         ports:
         - containerPort: 8080
 ---

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/trial.yaml
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/manifests/app/trial.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: trial
-        image: ghcr.io/thejaysmith/trial:v1
+        image: ghcr.io/jasonsmithio/trial:v1
         ports:
         - containerPort: 8080
 ---

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/reference-app/manifests/app/frontend-deployment.yaml
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/reference-app/manifests/app/frontend-deployment.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: ghcr.io/thejaysmith/myfrontend:v1
+        image: ghcr.io/jasonsmithio/myfrontend:v1
         ports:
         - containerPort: 8080

--- a/Project_Starter_Files-Building_a_Metrics_Dashboard/reference-app/manifests/app/helloworld.yaml
+++ b/Project_Starter_Files-Building_a_Metrics_Dashboard/reference-app/manifests/app/helloworld.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: hello-python
-        image: ghcr.io/thejaysmith/helloflask:v1
+        image: ghcr.io/jasonsmithio/helloflask:v1
         imagePullPolicy: Always
         ports:
         - containerPort: 5000


### PR DESCRIPTION
Hi Code maintainers!

Jason Smith moved [his GitHub repository](https://github.com/thejaysmith) to the [new address](https://github.com/jasonsmithio), so the old container register links no longer work.
Old GitHub registry address: ghcr.io/thejaysmith
New GitHub registry address: ghcr.io/jasonsmithio
Related post from Jay: https://github.com/thejaysmith/IHaveMoved

This pull request updates all broken links in the repository.

Please let me know if you have more questions.

Alex